### PR TITLE
Purge old absolute_urls of a model when model instance is updated.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+django_varnish.egg-info/*
+*.pyc

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name = "django-varnish",
-    version = '0.1',
+    version = '0.1.1',
     url = 'http://opensource.washingtontimes.com/projects/django-varnish/',
     author = 'Justin Quick',
     author_email= 'justquick@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name = "django-varnish",
-    version = '0.1.1',
+    version = '0.1.2',
     url = 'http://opensource.washingtontimes.com/projects/django-varnish/',
     author = 'Justin Quick',
     author_email= 'justquick@gmail.com',

--- a/varnishapp/manager.py
+++ b/varnishapp/manager.py
@@ -4,3 +4,5 @@ from atexit import register
 
 manager = VarnishManager(getattr(settings, 'VARNISH_MANAGEMENT_ADDRS', ()))
 register(manager.close)
+
+from signals import *

--- a/varnishapp/signals.py
+++ b/varnishapp/signals.py
@@ -23,7 +23,7 @@ def purge_old_paths(abs_url):
         for p in oldpaths:
              
              try:
-                 manager.run('purge.url', r'^%s$' % str(p.old_path))
+                 manager.run('ban.url', r'^%s$' % str(p.old_path))
              except:
                  logger.warn('No varnish instance running. Could not purge %s' % str(p.old_path))
 
@@ -39,7 +39,7 @@ def absolute_url_purge_handler(sender, **kwargs):
         abs_url = instance.get_absolute_url()
         
         try:
-            manager.run('purge.url', r'^%s$' % abs_url)
+            manager.run('ban.url', r'^%s$' % abs_url)
         except:
             logger.warn('No varnish instance running. Could not purge %s ' % abs_url)
         

--- a/varnishapp/signals.py
+++ b/varnishapp/signals.py
@@ -74,7 +74,7 @@ def api_resource_purge_handler (sender, **kwargs):
         resource_url = instance.get_resource_url()
         
         try:
-            manager.run('purge.url', r'^%s' % resource_url)
+            manager.run('ban.url', r'^%s' % resource_url)
         except:
             logger.warn('No varnish instance running. Could not purge %s ' % resource_url)
     

--- a/varnishapp/signals.py
+++ b/varnishapp/signals.py
@@ -33,8 +33,10 @@ def absolute_url_purge_handler(sender, **kwargs):
     NB: It adds $ to the end of the purge, so no urls with parameters etc are purged, 
     only the url given by get_absolute_url itself
     """
+    instance = kwargs['instance']
+    
     if hasattr(instance, 'get_absolute_url'):
-        abs_url = kwargs['instance'].get_absolute_url()
+        abs_url = instance.get_absolute_url()
         
         try:
             manager.run('purge.url', r'^%s$' % abs_url)

--- a/varnishapp/signals.py
+++ b/varnishapp/signals.py
@@ -63,6 +63,8 @@ def api_resource_purge_handler (sender, **kwargs):
                                                 'api_name': 'v1',
                                                 'pk': self.id}) 
     
+    The method will purge all urls *starting* with the url  
+    
     """
     instance = kwargs['instance']
     

--- a/varnishapp/signals.py
+++ b/varnishapp/signals.py
@@ -33,15 +33,15 @@ def absolute_url_purge_handler(sender, **kwargs):
     NB: It adds $ to the end of the purge, so no urls with parameters etc are purged, 
     only the url given by get_absolute_url itself
     """
-    
-    abs_url = kwargs['instance'].get_absolute_url()
-    
-    try:
-        manager.run('purge.url', r'^%s$' % abs_url)
-    except:
-        logger.warn('No varnish instance running. Could not purge %s ' % abs_url)
-    
-    purge_old_paths(abs_url)
+    if hasattr(instance, 'get_absolute_url'):
+        abs_url = kwargs['instance'].get_absolute_url()
+        
+        try:
+            manager.run('purge.url', r'^%s$' % abs_url)
+        except:
+            logger.warn('No varnish instance running. Could not purge %s ' % abs_url)
+        
+        purge_old_paths(abs_url)
 
 for model in getattr(settings, 'VARNISH_WATCHED_MODELS', ()):
     post_save.connect(absolute_url_purge_handler, sender=get_model(*model.split('.')))

--- a/varnishapp/signals.py
+++ b/varnishapp/signals.py
@@ -1,11 +1,43 @@
 from django.db.models.signals import post_save
 from django.db.models import get_model
 from django.conf import settings
-from manager import manager
+from varnishapp.manager import manager
 
+import logging
+
+logger = logging.getLogger("varnish.invalidation")
+
+def purge_old_paths(abs_url):
+    
+    """
+    If django redirects is installed, search for new paths based on given absolute url 
+    and purge all the corresponding old paths to ensure the user gets a redirect to the 
+    new path and not an old cached version of the page
+    """
+    
+    if "django.contrib.redirects" in settings.INSTALLED_APPS:
+        from django.contrib.redirects.models import Redirect
+        
+        #find old paths for new path
+        oldpaths = Redirect.objects.filter(new_path=abs_url)
+        
+        for p in oldpaths:
+             logger.debug("OLD PATH TO PURGE: %s" % p.old_path)
+             
+             try:
+                 manager.run('purge.url', r'^%s$' % str(p.old_path))
+             except:
+                 logger.warn('No varnish instance running. Could not purge %s' % str(p.old_path))
 
 def absolute_url_purge_handler(sender, **kwargs):
-    manager.run('purge.url', r'^%s$' % kwargs['instance'].get_absolute_url())
+    abs_url = kwargs['instance'].get_absolute_url()
+    
+    try:
+        manager.run('purge.url', r'^%s$' % abs_url)
+    except:
+        logger.warn('No varnish instance running. Could not purge %s ' % abs_url)
+    
+    purge_old_paths(abs_url)
 
 for model in getattr(settings, 'VARNISH_WATCHED_MODELS', ()):
     post_save.connect(absolute_url_purge_handler, sender=get_model(*model.split('.')))

--- a/varnishapp/signals.py
+++ b/varnishapp/signals.py
@@ -7,6 +7,7 @@ import logging
 
 logger = logging.getLogger("varnish.invalidation")
 
+
 def purge_old_paths(abs_url):
     
     """
@@ -23,7 +24,7 @@ def purge_old_paths(abs_url):
         for p in oldpaths:
              
              try:
-                 manager.run('ban.url', r'^%s$' % str(p.old_path))
+                 resp = manager.run('ban.url', r'^%s$' % str(p.old_path))
              except:
                  logger.warn('No varnish instance running. Could not purge %s' % str(p.old_path))
 
@@ -39,7 +40,10 @@ def absolute_url_purge_handler(sender, **kwargs):
         abs_url = instance.get_absolute_url()
         
         try:
-            manager.run('ban.url', r'^%s$' % abs_url)
+            banurl = r'^%s$' % abs_url
+            logger.info("Banning %s" % banurl)
+            resp = manager.run('ban.url', banurl)
+            logger.info(resp)
         except:
             logger.warn('No varnish instance running. Could not purge %s ' % abs_url)
         

--- a/varnishapp/signals.py
+++ b/varnishapp/signals.py
@@ -28,6 +28,12 @@ def purge_old_paths(abs_url):
                  logger.warn('No varnish instance running. Could not purge %s' % str(p.old_path))
 
 def absolute_url_purge_handler(sender, **kwargs):
+    """
+    Purges the absolute url of the model instance
+    NB: It adds $ to the end of the purge, so no urls with parameters etc are purged, 
+    only the url given by get_absolute_url itself
+    """
+    
     abs_url = kwargs['instance'].get_absolute_url()
     
     try:
@@ -64,7 +70,7 @@ def api_resource_purge_handler (sender, **kwargs):
         resource_url = instance.get_resource_url()
         
         try:
-            manager.run('purge.url', r'^%s$' % resource_url)
+            manager.run('purge.url', r'^%s' % resource_url)
         except:
             logger.warn('No varnish instance running. Could not purge %s ' % resource_url)
     


### PR DESCRIPTION
When using Varnish to cache your pages (for long) and updating a model instance so that the slug and by that the url changes, varnish will still cache the old version. 

If you use Django redirects app (https://docs.djangoproject.com/en/1.3/ref/contrib/redirects/) you can easily store old versions of absolute_urls when updating a model. 

This addition checks if Django redirects is installed, and if so, purges all the old urls of the model you justed saved, so that the user gets a proper redirect and not an old version of your page if they use the old url.
